### PR TITLE
Added custom headers support (for authentication)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ exports.createClient = createClient = function ( hostOrConnOpts , clientOptsOrCb
   
   request.get({
     json : true,
-    url : httpOpts.host + httpOpts.base
+    url : httpOpts.host + httpOpts.base,
+    headers:  httpOpts.headers || {}
   },function(err,result,json){
     if (err) {
       return cb(err);

--- a/lib/NeoHttpClient.js
+++ b/lib/NeoHttpClient.js
@@ -18,10 +18,10 @@ NeoHttpClient.prototype.query = function ( query , params , cb ) {
   request.post({
     url : url,
     json : { query : query, params: params },
-    headers : {
+    headers : _.extend({
       "Accept" :  "application/json; charset=UTF-8",
       "X-Stream" : "true"
-    }
+    }, opts.headers || {})
   },function onBasicQueryResponse (httpError, response, body) {
     
     var err = null ;


### PR DESCRIPTION
The default neo4j setup requires user\password authentication, which can be achieved using the "Authorization" http header
